### PR TITLE
Makes special caption formatting optional & fixes short titles

### DIFF
--- a/R/memor.R
+++ b/R/memor.R
@@ -28,6 +28,8 @@
 #' @param lof T/F value for list of figures.
 #' @param number_sections T/F value for whether sections should be numbered.
 #' See ?rmarkdown::pdf_document for details
+#' @param fancy_captions T/F value for whether to apply special formatting to
+#' captions.
 #' @param latex_engine LaTeX engine. See ?rmarkdown::pdf_document for details
 #' @param ... other options to be passed to rmarkdown::pdf_document. See
 #' ?rmarkdown::pdf_document for details
@@ -43,30 +45,32 @@
 #' }
 #' 
 #' @export
-pdf_memo <- function(use_profile = TRUE, 
-                     logo = NULL, company = NULL, short_title = NULL, 
-                     watermark = NULL, confidential = FALSE, 
+pdf_memo <- function(use_profile = TRUE,
+                     logo = NULL, company = NULL, short_title = NULL,
+                     watermark = NULL, confidential = FALSE,
                      libertine = FALSE, chinese = FALSE,
                      logo_height = "1.2cm", watermark_color = "gray",
-                     footer_on_first_page = TRUE, 
-                     toc = FALSE, lot = FALSE, lof = FALSE, 
+                     footer_on_first_page = TRUE,
+                     toc = FALSE, lot = FALSE, lof = FALSE,
+                     fancy_captions = TRUE,
                      number_sections = TRUE, latex_engine = "xelatex", ...) {
   if (use_profile) {
     profile_file <- getOption("memor_profile", "~/memor-profile.yaml")
     profile_yaml <- try(yaml::read_yaml(profile_file), silent = TRUE)
     if (!class(profile_yaml) == "try-error") {
       profile_compare <- list(
-        logo = list(logo, NULL), company = list(company, NULL), 
-        short_title = list(short_title, NULL), 
-        watermark = list(watermark, NULL), 
-        confidential = list(confidential, FALSE), 
+        logo = list(logo, NULL), company = list(company, NULL),
+        short_title = list(short_title, NULL),
+        watermark = list(watermark, NULL),
+        confidential = list(confidential, FALSE),
         libertine = list(libertine, FALSE),
         chinese = list(chinese, FALSE),
-        logo_height = list(logo_height, "1.2cm"), 
+        logo_height = list(logo_height, "1.2cm"),
         watermark_color = list(watermark_color, "gray"),
-        footer_on_first_page = list(footer_on_first_page, TRUE), 
-        toc = list(toc, FALSE), lot = list(lot, FALSE), lof = list(lof, FALSE), 
-        number_sections = list(number_sections, TRUE), 
+        footer_on_first_page = list(footer_on_first_page, TRUE),
+        toc = list(toc, FALSE), lot = list(lot, FALSE), lof = list(lof, FALSE),
+        number_sections = list(number_sections, TRUE),
+        fancy_captions = list(fancy_captions, TRUE),
         latex_engine = list(latex_engine, "xelatex")
       )
       changed_items <- lapply(profile_compare, function(x){
@@ -130,6 +134,10 @@ pdf_memo <- function(use_profile = TRUE,
   
   if (lot) memor_args <- c(memor_args, pandoc_variable_arg("lot", "yes"))
   if (lof) memor_args <- c(memor_args, pandoc_variable_arg("lof", "yes"))
+  
+  if (fancy_captions) {
+    memor_args <- c(memor_args, pandoc_variable_arg("fancy_captions", "yes"))
+  }
   
   template <- system.file("rmarkdown/templates/memor/resources/memor.tex",
                           package = "memor")

--- a/R/memor.R
+++ b/R/memor.R
@@ -26,7 +26,7 @@
 #' for details
 #' @param lot T/F value for list of tables.
 #' @param lof T/F value for list of figures.
-#' @param number_sections logical value for wether sections should be numbered.
+#' @param number_sections T/F value for whether sections should be numbered.
 #' See ?rmarkdown::pdf_document for details
 #' @param latex_engine LaTeX engine. See ?rmarkdown::pdf_document for details
 #' @param ... other options to be passed to rmarkdown::pdf_document. See

--- a/R/memor.R
+++ b/R/memor.R
@@ -103,7 +103,7 @@ pdf_memo <- function(use_profile = TRUE,
   }
   
   if (!is.null(short_title)) {
-    memor_args <- c(memor_args, pandoc_variable_arg("shotr_title", short_title))
+    memor_args <- c(memor_args, pandoc_variable_arg("short_title", short_title))
   }
   
   if (footer_on_first_page) {

--- a/inst/rmarkdown/templates/memor/resources/memor.tex
+++ b/inst/rmarkdown/templates/memor/resources/memor.tex
@@ -225,10 +225,14 @@ $endif$
 
 % table/figure captions (titles and legends)
 \usepackage{caption}
+$if(fancy_captions)$
 \DeclareCaptionFormat{llap}{\llap{#1#2}#3\par} % table / figure number in left margin
 \DeclareCaptionLabelSeparator{spc}{\hspace{.075 in}} % space between table number and caption
 \captionsetup{font={color=$if(citecolor)$$citecolor$$else$blue$endif$, sf}, singlelinecheck=off, margin= 15pt, skip=4pt, size=small, labelfont={sc, sf}, format=llap, labelsep=spc,singlelinecheck=no} % same font as headers
-
+$else$
+% otherwise just 
+\captionsetup{font=small, labelfont={sc, bf}}
+$endif$
 
 \makeatletter
 \let\runtitle\@title

--- a/man/pdf_memo.Rd
+++ b/man/pdf_memo.Rd
@@ -52,7 +52,6 @@ for details}
 
 \item{lof}{T/F value for list of figures.}
 
-\item{number_sections}{logical value for wether sections should be numbered.
 See ?rmarkdown::pdf_document for details}
 
 \item{latex_engine}{LaTeX engine. See ?rmarkdown::pdf_document for details}

--- a/man/pdf_memo.Rd
+++ b/man/pdf_memo.Rd
@@ -8,8 +8,8 @@ pdf_memo(use_profile = TRUE, logo = NULL, company = NULL,
   short_title = NULL, watermark = NULL, confidential = FALSE,
   libertine = FALSE, chinese = FALSE, logo_height = "1.2cm",
   watermark_color = "gray", footer_on_first_page = TRUE, toc = FALSE,
-  lot = FALSE, lof = FALSE, number_sections = TRUE,
-  latex_engine = "xelatex", ...)
+  lot = FALSE, lof = FALSE, fancy_captions = TRUE,
+  number_sections = TRUE, latex_engine = "xelatex", ...)
 }
 \arguments{
 \item{use_profile}{T/F value for whether the user profile in
@@ -52,6 +52,10 @@ for details}
 
 \item{lof}{T/F value for list of figures.}
 
+\item{fancy_captions}{T/F value for whether to apply special formatting to
+captions.}
+
+\item{number_sections}{T/F value for whether sections should be numbered.
 See ?rmarkdown::pdf_document for details}
 
 \item{latex_engine}{LaTeX engine. See ?rmarkdown::pdf_document for details}


### PR DESCRIPTION
# Changes/fixes

- Previously short titles didn't work due to a typo
- Description for `number_section` param is more consistent with the rest of the params

# Additions

- Adds `fancy_captions` setting (yes by default as it's formatting that memor originally shipped with); disabling this option makes the template apply only a little bit of formatting

Compare `fancy_captions: yes` (default) with `fancy_captions: no`:

![Fancy caption formatting example (memor default)](https://user-images.githubusercontent.com/1807519/42392840-196bde0a-8109-11e8-977f-bc46e468da38.png)
![Simple caption formatting example](https://user-images.githubusercontent.com/1807519/42393144-48ea0fd4-810a-11e8-8ef0-d4d820b15395.png)

## Example application

I'm using [Source Serif Pro](https://typekit.com/fonts/source-serif) as the font for all non-section-heading font, so the simpler, "non-fancy" formatting allows the captions to look more consistent with the rest of the report:

![Another simple caption formatting example](https://user-images.githubusercontent.com/1807519/42393296-c6b2c8ca-810a-11e8-8ef8-1375202f964c.png)