### PR TITLE
Support for bibliographies when using recent versions of pandoc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: memor
 Title: A 'rmarkdown' Template that Can be Highly Customized
-Version: 0.2.0.9000
+Version: 0.2.1.9000
 Authors@R: c(
     person("Hao", "Zhu", email = "haozhu233@gmail.com", role = c("aut", "cre"), 
     comment = c(ORCID = '0000-0002-3386-6076')),
@@ -24,5 +24,5 @@ Suggests:
     kableExtra, ggplot2
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)

--- a/inst/rmarkdown/templates/memor/resources/memor.tex
+++ b/inst/rmarkdown/templates/memor/resources/memor.tex
@@ -90,6 +90,14 @@ $for(bibliography)$
 \addbibresource{$bibliography$}
 $endfor$
 $endif$
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}
+  {\par}
+$endif$
 $if(listings)$
 \usepackage{listings}
 $endif$
@@ -221,7 +229,7 @@ $if(fancy_captions)$
 \DeclareCaptionLabelSeparator{spc}{\hspace{.075 in}} % space between table number and caption
 \captionsetup{font={color=$if(citecolor)$$citecolor$$else$blue$endif$, sf}, singlelinecheck=off, margin= 15pt, skip=4pt, size=small, labelfont={sc, sf}, format=llap, labelsep=spc,singlelinecheck=no} % same font as headers
 $else$
-% otherwise just 
+% otherwise just
 \captionsetup{font=small, labelfont={sc, bf}}
 $endif$
 


### PR DESCRIPTION
Resolves #8 

**P.S.** The version change was for dependency management and ensuring that my {memor}-based template only worked when using the fork that included the fix.